### PR TITLE
Add new pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.5
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python


### PR DESCRIPTION
- Add the latest pre-commit configuration from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/new-linter-precommit-add-rest`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/new-linter-precommit-add-rest)